### PR TITLE
Fix typeJSON.properties parsing

### DIFF
--- a/packages/stadt/src/json.ts
+++ b/packages/stadt/src/json.ts
@@ -138,7 +138,9 @@ export function fromJSON(typeJSON: TypeJSON): adt.Type {
     case adt.TypeKind.Untranslated:
       return new adt.UntranslatedType(typeJSON.asString);
     case adt.TypeKind.Object: {
-      const properties = (typeJSON.properties || []).map(propertyFromJSON);
+      const properties = Array.isArray(typeJSON.properties)
+        ? typeJSON.properties.map(propertyFromJSON)
+        : [];
       const callSignatures = typeJSON.callSignatures
         ? typeJSON.callSignatures.map(signatureFromJSON)
         : undefined;


### PR DESCRIPTION
Hi, 
this pull request is just another way to create an issue, because there is no such possibility in this repo right now, I am not able to test this code, it's just my theory.

The issue is that while running `typed-ast-rules-example` analyzer (https://github.com/returntocorp/typed-ast-rules-example) at app.r2c.dev a lot of packages fails due to this particular error

```
Failure TypeError: (typeJSON.properties || []).map is not a function
    at fromJSON (/analyzer/node_modules/stadt/dist/json.js:51:60)
    at Array.map (<anonymous>)
    at fromJSON (/analyzer/node_modules/stadt/dist/json.js:58:110)
    at parameterFromJSON (/analyzer/node_modules/stadt/dist/json.js:81:15)
    at Array.map (<anonymous>)
    at signatureFromJSON (/analyzer/node_modules/stadt/dist/json.js:74:46)
    at Array.map (<anonymous>)
    at fromJSON (/analyzer/node_modules/stadt/dist/json.js:53:43)
    at parameterFromJSON (/analyzer/node_modules/stadt/dist/json.js:81:15)
    at Array.map (<anonymous>)
```